### PR TITLE
Also test benchmarks, clean optimization flags

### DIFF
--- a/CMake/GenMacros.cmake
+++ b/CMake/GenMacros.cmake
@@ -357,6 +357,8 @@ macro(ADD_SMIL_TESTS _LIB_NAME)
           target_link_libraries(${TEST_NAME} ${PYTHON_LIBRARIES})
           add_dependencies(tests ${TEST_NAME})
         elseif(${_EXE_PREFIX} STREQUAL "bench")
+          add_test(NAME "${MOD_NAME}${TEST_NAME}"
+                   COMMAND ${EXECUTABLE_OUTPUT_PATH}/${TEST_NAME})
           add_dependencies(benchs ${TEST_NAME})
         endif(${_EXE_PREFIX} STREQUAL "test")
       endforeach(_SRC ${TEST_SOURCE_FILES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,15 +262,6 @@ endif(MSVC)
 
 # OPTIMIZATIONS ######
 
-option(USE_SSE_INT "Use sse intrinsics" OFF)
-mark_as_advanced(USE_SSE_INT)
-if(USE_SSE_INT)
-  add_definitions("-DSMIL_USE_SSE_INT")
-endif(USE_SSE_INT)
-
-# INCLUDE(CompilerFlags)
-
-include(OptimizeForArchitecture)
 option(USE_OPTIMIZATION "Use optimizations" ON)
 if(USE_OPTIMIZATION)
   set(TARGET_ARCHITECTURE
@@ -284,25 +275,18 @@ if(USE_OPTIMIZATION)
   mark_as_advanced(VERBOSE_OPTIMIZATION)
 
   if(CMAKE_COMPILER_IS_GNUCC)
-    addcompilerflag("-ftree-vectorize -ftree-slp-vectorize")
     if(TARGET_ARCHITECTURE STREQUAL "auto")
-      addcompilerflag("-march=native -mtune=generic")
-      # OptimizeForArchitecture()
-    else(TARGET_ARCHITECTURE STREQUAL "auto")
-      addcompilerflag("-march=${TARGET_ARCHITECTURE} -mtune=generic")
-    endif(TARGET_ARCHITECTURE STREQUAL "auto")
+      add_compile_options(-march=native -mtune=generic)
+    else()
+      add_compile_options(-march=${TARGET_ARCHITECTURE} -mtune=generic)
+    endif()
+
     if(VERBOSE_OPTIMIZATION)
-      add_definitions("-ftree-vectorizer-verbose=1")
-    endif(VERBOSE_OPTIMIZATION)
-  elseif(CMAKE_COMPILER_IS_CLANGXX)
-    # ADD_DEFINITIONS(" -mllvm -vectorize")
-  else(CMAKE_COMPILER_IS_GNUCC)
-    optimizeforarchitecture()
-  endif(CMAKE_COMPILER_IS_GNUCC)
-  message(STATUS "Compiler flags: ${CMAKE_CXX_FLAGS}")
-else(USE_OPTIMIZATION)
-  addcompilerflag("-fno-tree-vectorize")
-endif(USE_OPTIMIZATION)
+      add_compile_options(-ftree-vectorizer-verbose=1)
+    endif()
+
+  endif()
+endif()
 
 if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND NOT WIN32)
   find_package(OpenMP QUIET)


### PR DESCRIPTION
This PR adds the C++ benchmarks to be executed alongside the other tests through `ctest`. This means they will also be executed in the GitHub Actions workflows.

Also, the CPU optimization flags set by the CMake code have been cleaned. According to https://gcc.gnu.org/projects/tree-ssa/vectorization.html#using, `-ftree-vectorize` is enabled by default under `-O3` and enables `-ftree-slp-vectorize`. Compiling in CMake Release mode (`-O3 -DNDEBUG`) should be enough to get vectorized code (at least under GCC). Local testing show no perf degradation in `bench_base_arithmetic`. This might help with "Illegal instructions" error too.

Pierre