### PR TITLE
GitHub Actions: Generate a statically-linked Python wheel on Windows

### DIFF
--- a/.github/workflows/publish_windows-latest_msvc.yml
+++ b/.github/workflows/publish_windows-latest_msvc.yml
@@ -1,0 +1,154 @@
+name: publish_windows-latest_msvc
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        py: [
+          "3.9",
+          "3.10",
+          "3.11",
+          "3.12",
+          "3.13",
+        ]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prepare dependencies
+        run: |
+          echo '{
+            "dependencies": [ "libpng", "tiff", "curl", "freetype" ]
+          }' > vcpkg.json
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.py }}
+
+      - name: Install python dependencies
+        run: |
+          pip install swig numpy build
+
+      - name: Set up Visual Studio shell
+        uses: egor-tensin/vs-shell@v2
+
+      - name: Create & configure Smil build directory
+        run: |
+          mkdir build && cd build
+          cmake \
+            -DCMAKE_COMPILE_WARNING_AS_ERROR=ON \
+            -DVCPKG_HOST_TRIPLET=x64-windows-static \
+            -DVCPKG_TARGET_TRIPLET=x64-windows-static \
+            -DBUILD_TEST=ON \
+            -DWRAP_PYTHON=ON \
+            -DUSE_NUMPY=ON \
+            $GITHUB_WORKSPACE
+        shell: bash
+        env:
+          CMAKE_GENERATOR: "Visual Studio 17 2022"
+          CMAKE_BUILD_TYPE: Release
+          CMAKE_TOOLCHAIN_FILE : C:\vcpkg\scripts\buildsystems\vcpkg.cmake
+
+      - name: Build Smil
+        run: |
+          cmake --build build --config Release
+
+      - name: Build Python package
+        run: |
+          cmake --build build --config Release --target python_package
+
+      - name: Build wheel from Python package
+        run: |
+          cd build\python
+          python -m build --wheel -C="--build-option=--plat-name=win_amd64"
+          cd ..\..
+          $PKG_PATH = Get-ChildItem -Path "build/python/dist/*" -File
+          echo "MY_PKG=$PKG_PATH" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-python-package-x64-${{ matrix.py }}
+          path: ${{ env.MY_PKG }}
+
+  test:
+    runs-on: windows-latest
+    needs: build
+    strategy:
+      matrix:
+        py: [
+          "3.9",
+          "3.10",
+          "3.11",
+          "3.12",
+          "3.13",
+        ]
+    env:
+      QT_QPA_PLATFORM: offscreen
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: windows-python-package-x64-${{ matrix.py }}
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: ${{ matrix.py }}
+          activate-environment: true
+
+      - name: Install Python package
+        run: |
+          uv pip install "$(ls *.whl)"
+
+      - name: Test Python import
+        run: |
+          python -c 'import smilPython as sp; dir(sp)'
+
+      - name: Test Python scripts
+        run: |
+          Copy-Item -Path "images\*" -Destination "doc\demos\python" -Recurse
+          cd doc/demos/python/
+          python base_graph.py
+          python benchs.py
+          python blob_measures.py
+          python constrained_watershed.py
+          python copy_crop.py
+          python example-3D-image-rotate.py
+          python example-areathreshold.py
+          python example-asfclose.py
+          python example-bresenham.py
+          python example-default-se.py
+          python example-distance-geodesic.py
+          python example-gaussian-filter.py
+          python example-horiz-convolve.py
+          python example-imagefileinfo-print.py
+          python example-inertia-matrix.py
+          python example-intro-blobs.py
+          python example-point-minus.py
+          python example-read.py
+          python example-readRAW.py
+          python extinction_values.py
+          python first-program.py
+          python hit_or_miss.py
+          python loop-input.py
+          python loop-sleep.py
+          python multichannel_operations.py
+          python numpy_array.py
+          python numpy_np2image.py
+          python numpy_np2sp.py
+          python numpy_sp2np2sp.py
+          python numpy_sp2np.py
+          python operators.py
+          python skiz.py
+          python thresholds.py
+          python x_image_01.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -766,6 +766,7 @@ if(USE_WRAPPER)
     endif(UNIX)
 
     add_dependencies(python smil_Python)
+    add_subdirectory(python)
   endif(WRAP_PYTHON)
 
   if(WRAP_JAVA)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,0 +1,63 @@
+# Python package name
+set(PYTHON_PACKAGE_NAME smilPython)
+
+# ##############################################################################
+# DEPENDENCIES
+
+# Look for Python3
+string(REGEX MATCH "^([0-9]+)\\.([0-9]+)\\.([0-9]+)"
+             Python3_NumPy_VERSION_MATCH ${Python3_NumPy_VERSION})
+set(Python3_NumPy_VERSION_MAJOR ${CMAKE_MATCH_1})
+math(EXPR Python3_NumPy_NEXT_MAJOR "${Python3_NumPy_VERSION_MAJOR} + 1")
+message(
+  STATUS
+    "Found Numpy Version ${Python3_NumPy_VERSION} in ${Python3_NumPy_INCLUDE_DIRS}"
+)
+
+# ##############################################################################
+# PACKAGING (target independent)
+
+# Generate setup.py automatically for each configuration First step: replace
+# variables (@VAR@)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in
+               ${CMAKE_CURRENT_BINARY_DIR}/setup.py @ONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/pyproject.toml.in
+               ${CMAKE_CURRENT_BINARY_DIR}/pyproject.toml.in @ONLY)
+
+# Second step: replace generator expression ($<>)
+file(
+  GENERATE
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/pyproject.toml
+  INPUT ${CMAKE_CURRENT_BINARY_DIR}/pyproject.toml.in)
+
+# Generate README.md for each configuration
+file(
+  GENERATE
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/README.md
+  INPUT ${CMAKE_SOURCE_DIR}/README.md)
+
+# Copy each modules to package *destination* folder for each configuration
+file(GLOB MODULES ${CMAKE_CURRENT_SOURCE_DIR}/modules/*.py)
+foreach(MODULE ${MODULES})
+  cmake_path(GET MODULE FILENAME MODULE_NAME)
+  set(MODULE_NAME ${PYTHON_PACKAGE_NAME}/${MODULE_NAME})
+  file(
+    GENERATE
+    OUTPUT ${PYTHON_PACKAGE_ROOT_FOLDER}/${MODULE_NAME}
+    INPUT ${MODULE})
+endforeach()
+
+add_custom_target(
+  python_package
+  COMMAND
+    ${CMAKE_COMMAND} -E copy_directory
+    ${CMAKE_BINARY_DIR}/lib/${PYTHON_PACKAGE_NAME}
+    ${CMAKE_CURRENT_BINARY_DIR}/${PYTHON_PACKAGE_NAME}
+  COMMAND
+    ${CMAKE_COMMAND} -E copy $<TARGET_FILE:smil_Python>
+    $<TARGET_FILE:smilAdvancedPython> $<TARGET_FILE:smilBasePython>
+    $<TARGET_FILE:smilCorePython> $<TARGET_FILE:smilGuiPython>
+    $<TARGET_FILE:smilIOPython> $<TARGET_FILE:smilMorphoPython>
+    ${CMAKE_CURRENT_BINARY_DIR}/${PYTHON_PACKAGE_NAME})
+
+add_dependencies(python_package smil_Python)

--- a/python/pyproject.toml.in
+++ b/python/pyproject.toml.in
@@ -1,0 +1,54 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "smilPython"
+version = "@CMAKE_PROJECT_VERSION@"
+authors = [
+  {name = "Mathieu Faessel", email = "Mathieu.Faessel@mines-paristech.fr"},
+  {name = "Jose-Marcio Martins da Cruz", email = "Jose-Marcio.Martins@mines-paristech.fr"},
+  {name = "Théodore Chabardès", email = "theodore.chabardes@mines-paristech.fr"},
+  {name = "Beatriz Marcotegui", email = "Beatriz.Marcotegui@mines-paristech.fr"},
+  {name = "Pierre Guillou", email = "pierre.guillou@minesparis.psl.eu"},
+  {name = "Michel Bilodeau", email = "Michel.Bilodeau@mines-paristech.fr"},
+  {name = "Etienne Decenciere", email = "Etienne.Decenciere@mines-paristech.fr"},
+  {name = "Amin Fehri", email = "Amin.Fehri@mines-paristech.fr"},
+  {name = "Serge Koudoro", email = "Serge.Koudoro@mines-paristech.fr"},
+]
+description = "Smil, Simple Morphological Image Library"
+readme = "README.md"
+license = {text = 'GPL'}
+requires-python = '>=3.9'
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: C++",
+    "Development Status :: 4 - Beta",
+    "Environment :: Other Environment",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+dependencies = [
+    # from the oldest supported numpy to the next major version of the
+    # numpy install used in building gstlearn
+    "numpy>=1.24,<@Python3_NumPy_NEXT_MAJOR@",
+]
+
+[project.urls]
+Homepage = "https://github.com/MinesParis-MorphoMath/smil"
+Issues = "https://github.com/MinesParis-MorphoMath/smil/issues"
+
+[tool.setuptools]
+py-modules = []
+packages = ["@PYTHON_PACKAGE_NAME@"]
+package-data = {"@PYTHON_PACKAGE_NAME@" = [
+    "$<TARGET_FILE_NAME:smil_Python>",
+    "$<TARGET_FILE_NAME:smilAdvancedPython>",
+    "$<TARGET_FILE_NAME:smilBasePython>",
+    "$<TARGET_FILE_NAME:smilCorePython>",
+    "$<TARGET_FILE_NAME:smilGuiPython>",
+    "$<TARGET_FILE_NAME:smilIOPython>",
+    "$<TARGET_FILE_NAME:smilMorphoPython>"
+]}
+platforms = ["Windows", "Linux", "Mac OS-X"]

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -1,0 +1,45 @@
+# Copyright (c) 2011-2016, Matthieu FAESSEL and ARMINES All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of Matthieu FAESSEL, or ARMINES nor the names of its
+#   contributors may be used to endorse or promote products derived from this
+#   software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import setuptools
+from setuptools.command.build_ext import build_ext
+
+
+class DummyExtensionBuild(build_ext):
+    def run(self) -> None:
+        return
+
+
+setuptools.setup(
+    # we add an empty dummy extension to get a platform wheel...
+    ext_modules=[
+        setuptools.Extension(
+            name="dummy_extension_for_platform_wheel",
+            sources=[],
+        )
+    ],
+    # ...and we make sure to skip its compilation
+    cmdclass={"build_ext": DummyExtensionBuild},
+)


### PR DESCRIPTION
This PR adds a new GitHub Actions workflow, `publish_windows-latest_msvc`, that builds Smil with statically linked dependencies into a Python wheel, that can be installed on other Windows machines without the need to installed these dependencies.

This workflow is using `vcpkg` to build the following dependencies: `png`, `tiff`, `jpeg`, `curl` and `freetype`, as static libraries. `qt5` and `qwt` are not supported yet.

A new CMake target, `python_package` has been introduced to copy rhe Smil `dll`s generated with CMake and Swig into a Python package directory, containing the Python sources and manifest files: `pyproject.toml` and `setup.py`. From there, a Python wheel can be generated with the `build` Python package.

In the workflow, once the wheel has been generated, it is tested in another job (to reinitialize the environment). The Python scripts inside `doc/demos/python` are then run without the need to install the dependencies.

Example workflow run: https://github.com/pierre-guillou/smil/actions/runs/18218432155

Pierre